### PR TITLE
[[FEAT]] statusCode on HTTP to be a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ try {
 ```js
 let err = new Therror.HTTP.NotFound('The user ${user} does not exists', {user: 'Sarah'});
 
-res.statusCode(err.statusCode()) // 404
+res.statusCode(err.statusCode) // 404
 res.json(err.toPayload())
 // {
 //    error: 'NotFound',
@@ -105,7 +105,7 @@ let err = new Therror.HTTP.ServiceUnavailable('BD Misconfigured');
 console.log(err); // [ServiceUnavailable: BD Misconfigured]
 
 // Send a hidden response to the client (Express example)
-res.statusCode(err.statusCode()) // 503
+res.statusCode(err.statusCode) // 503
 res.json(err.toPayload())
 // {
 //    error: 'InternalServerError',
@@ -236,7 +236,7 @@ class UserNotFound extends Therror.HTTP('404') {}
 let err = new UserNotFound('The user ${user} does not exists', {user: 'Sarah'});
 
 // Send the response (Express example)
-res.statusCode(err.statusCode()) // 404
+res.statusCode(err.statusCode) // 404
 res.json(err.toPayload())
 // {
 //    error: 'UserNotFound',
@@ -250,7 +250,7 @@ let err = new DatabaseError(cause, 'BD Misconfigured');
 console.log(err); // [DatabaseError: BD Misconfigured]
 
 // Send a hidden response to the client (Express example)
-res.statusCode(err.statusCode()) // 503
+res.statusCode(err.statusCode) // 503
 res.json(err.toPayload())
 // {
 //    error: 'InternalServerError',

--- a/lib/therror.js
+++ b/lib/therror.js
@@ -325,7 +325,7 @@ class Therror extends Error {
    *
    * let err = new UserNotFound('The user ${user} does not exists', {user: 'Sarah'});
    *
-   * res.statusCode(err.statusCode()) // 404
+   * res.statusCode(err.statusCode) // 404
    * res.json(err.toPayload())
    * // {
    * //    error: 'UserNotFound',
@@ -339,7 +339,7 @@ class Therror extends Error {
    * ```js
    * let err = new Therror.HTTP.NotFound('The user ${user} does not exists', {user: 'Sarah'});
    *
-   * res.statusCode(err.statusCode()) // 404
+   * res.statusCode(err.statusCode) // 404
    * res.json(err.toPayload())
    * // {
    * //    error: 'NotFound',
@@ -401,7 +401,7 @@ class Therror extends Error {
         };
       }
 
-      statusCode() {
+      get statusCode() {
         return statusCode;
       }
     };

--- a/test/therror.spec.js
+++ b/test/therror.spec.js
@@ -348,10 +348,11 @@ describe('Therror', function() {
       let err = new NotFound();
       let err2 = new ServerError(err, 'Boom!');
 
-      expect(err).to.respondTo('statusCode');
+      expect(err.statusCode).to.exist;
+      expect(Object.keys(err)).to.not.contains('statusCode');
       expect(err).to.respondTo('toPayload');
 
-      expect(err.statusCode()).to.be.eql(404);
+      expect(err.statusCode).to.be.eql(404);
       expect(err.message).to.be.eql('Not Found');
       expect(err.toPayload()).to.be.eql({
         error: 'NotFound',
@@ -369,10 +370,7 @@ describe('Therror', function() {
 
       let err = new UserNotFound('The user ${user} does not exists', {user: 'Sarah'});
 
-      expect(err).to.respondTo('statusCode');
-      expect(err).to.respondTo('toPayload');
-
-      expect(err.statusCode()).to.be.eql(404);
+      expect(err.statusCode).to.be.eql(404);
       expect(err.message).to.be.eql('The user Sarah does not exists');
       expect(err.toPayload()).to.be.eql({
         error: 'UserNotFound',
@@ -384,10 +382,7 @@ describe('Therror', function() {
 
       let err = new Therror.HTTP.NotFound('The user ${user} does not exists', {user: 'Sarah'});
 
-      expect(err).to.respondTo('statusCode');
-      expect(err).to.respondTo('toPayload');
-
-      expect(err.statusCode()).to.be.eql(404);
+      expect(err.statusCode).to.be.eql(404);
       expect(err.message).to.be.eql('The user Sarah does not exists');
       expect(err.toPayload()).to.be.eql({
         error: 'NotFound',
@@ -398,10 +393,7 @@ describe('Therror', function() {
     it('should hide information to the client', function() {
       let err = new Therror.HTTP.ServiceUnavailable('Database ${type} misconfigured', {type: 'mongo'});
 
-      expect(err).to.respondTo('statusCode');
-      expect(err).to.respondTo('toPayload');
-
-      expect(err.statusCode()).to.be.eql(503);
+      expect(err.statusCode).to.be.eql(503);
       expect(err.name).to.be.eql('ServiceUnavailable');
       expect(err.message).to.be.eql('Database mongo misconfigured');
       expect(err.toPayload()).to.be.eql({
@@ -416,7 +408,7 @@ describe('Therror', function() {
       let err = new ServerError();
       let err2 = new ServerError('Boom!');
 
-      expect(err.statusCode()).to.be.eql(2312332);
+      expect(err.statusCode).to.be.eql(2312332);
       expect(err.message).to.be.eql('Internal Server Error');
       expect(err2.message).to.be.eql('Boom!');
 
@@ -452,7 +444,7 @@ describe('Therror', function() {
       expect(err.cause()).to.be.eql(cause);
       expect(err.message).to.be.eql('The user is John');
       expect(err.level()).to.be.eql('info');
-      expect(err.statusCode()).to.be.eql(404);
+      expect(err.statusCode).to.be.eql(404);
       expect(eventSpy).to.have.been.calledWith(err);
     });
 
@@ -465,7 +457,7 @@ describe('Therror', function() {
       expect(err.cause()).to.be.eql(cause);
       expect(err.message).to.be.eql('Service Unavailable');
       expect(err.level()).to.be.eql('error');
-      expect(err.statusCode()).to.be.eql(503);
+      expect(err.statusCode).to.be.eql(503);
     });
   });
 });


### PR DESCRIPTION
This change will give more compatibility with famous frameworks that are error aware, such Hapi and Express. They use `statusCode` as a error property instead of a getter function. 

[Boom (HapiJS)](https://github.com/hapijs/boom/blob/c3b3c6b8137d719c9afcb890020a5c55c3d3a0c5/lib/index.js#L109)
[Express](https://github.com/expressjs/errorhandler/blob/333221a9f1fef81e8d0f69cf54f92410b51d6a85/index.js#L85)