### PR TITLE
[[FEAT]] Precreated ServerError error level

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ having the original properties untouched to log the error as it was defined
 let err = new Therror.ServerError.ServiceUnavailable('BD Misconfigured');
 
 // Log the real error data
+// errors with statusCode < 500 will be logged as info. >= 500 will be logged as 'error'
 console.log(err); // [ServiceUnavailable: BD Misconfigured]
 
 // but send a hidden response to the client (Express example)

--- a/lib/therror.d.ts
+++ b/lib/therror.d.ts
@@ -385,196 +385,196 @@ declare namespace Mixins {
     namespace ServerErrors {
         interface  BadRequest extends Classes.ServerError {}
         interface  BadRequestConstructor extends TherrorConstructor<BadRequest> {
-            /** ServerError with statusCode: 400, message: 'Bad Request', level: 'error' */
+            /** ServerError with statusCode: 400, message: 'Bad Request', level: 'info' */
             new(): BadRequest;
         }
         export let BadRequest: BadRequestConstructor;
 
         interface  Unauthorized extends Classes.ServerError {}
         interface  UnauthorizedConstructor extends TherrorConstructor<Unauthorized> {
-            /** ServerError with statusCode: 401, message: 'Unauthorized', level: 'error' */
+            /** ServerError with statusCode: 401, message: 'Unauthorized', level: 'info' */
             new(): Unauthorized;
         }
         export let Unauthorized: UnauthorizedConstructor;
 
         interface  PaymentRequired extends Classes.ServerError {}
         interface  PaymentRequiredConstructor extends TherrorConstructor<PaymentRequired> {
-            /** ServerError with statusCode: 402, message: 'Payment Required', level: 'error' */
+            /** ServerError with statusCode: 402, message: 'Payment Required', level: 'info' */
             new(): PaymentRequired;
         }
         export let PaymentRequired: PaymentRequiredConstructor;
 
         interface  Forbidden extends Classes.ServerError {}
         interface  ForbiddenConstructor extends TherrorConstructor<Forbidden> {
-            /** ServerError with statusCode: 403, message: 'Forbidden', level: 'error' */
+            /** ServerError with statusCode: 403, message: 'Forbidden', level: 'info' */
             new(): Forbidden;
         }
         export let Forbidden: ForbiddenConstructor;
 
         interface  NotFound extends Classes.ServerError {}
         interface  NotFoundConstructor extends TherrorConstructor<NotFound> {
-            /** ServerError with statusCode: 404, message: 'Not Found', level: 'error' */
+            /** ServerError with statusCode: 404, message: 'Not Found', level: 'info' */
             new(): NotFound;
         }
         export let NotFound: NotFoundConstructor;
 
         interface  MethodNotAllowed extends Classes.ServerError {}
         interface  MethodNotAllowedConstructor extends TherrorConstructor<MethodNotAllowed> {
-            /** ServerError with statusCode: 405, message: 'Method Not Allowed', level: 'error' */
+            /** ServerError with statusCode: 405, message: 'Method Not Allowed', level: 'info' */
             new(): MethodNotAllowed;
         }
         export let MethodNotAllowed: MethodNotAllowedConstructor;
 
         interface  NotAcceptable extends Classes.ServerError {}
         interface  NotAcceptableConstructor extends TherrorConstructor<NotAcceptable> {
-            /** ServerError with statusCode: 406, message: 'Not Acceptable', level: 'error' */
+            /** ServerError with statusCode: 406, message: 'Not Acceptable', level: 'info' */
             new(): NotAcceptable;
         }
         export let NotAcceptable: NotAcceptableConstructor;
 
         interface  ProxyAuthenticationRequired extends Classes.ServerError {}
         interface  ProxyAuthenticationRequiredConstructor extends TherrorConstructor<ProxyAuthenticationRequired> {
-            /** ServerError with statusCode: 407, message: 'Proxy Authentication Required', level: 'error' */
+            /** ServerError with statusCode: 407, message: 'Proxy Authentication Required', level: 'info' */
             new(): ProxyAuthenticationRequired;
         }
         export let ProxyAuthenticationRequired: ProxyAuthenticationRequiredConstructor;
 
         interface  RequestTimeout extends Classes.ServerError {}
         interface  RequestTimeoutConstructor extends TherrorConstructor<RequestTimeout> {
-            /** ServerError with statusCode: 408, message: 'Request Timeout', level: 'error' */
+            /** ServerError with statusCode: 408, message: 'Request Timeout', level: 'info' */
             new(): RequestTimeout;
         }
         export let RequestTimeout: RequestTimeoutConstructor;
 
         interface  Conflict extends Classes.ServerError {}
         interface  ConflictConstructor extends TherrorConstructor<Conflict> {
-            /** ServerError with statusCode: 409, message: 'Conflict', level: 'error' */
+            /** ServerError with statusCode: 409, message: 'Conflict', level: 'info' */
             new(): Conflict;
         }
         export let Conflict: ConflictConstructor;
 
         interface  Gone extends Classes.ServerError {}
         interface  GoneConstructor extends TherrorConstructor<Gone> {
-            /** ServerError with statusCode: 410, message: 'Gone', level: 'error' */
+            /** ServerError with statusCode: 410, message: 'Gone', level: 'info' */
             new(): Gone;
         }
         export let Gone: GoneConstructor;
 
         interface  LengthRequired extends Classes.ServerError {}
         interface  LengthRequiredConstructor extends TherrorConstructor<LengthRequired> {
-            /** ServerError with statusCode: 411, message: 'Length Required', level: 'error' */
+            /** ServerError with statusCode: 411, message: 'Length Required', level: 'info' */
             new(): LengthRequired;
         }
         export let LengthRequired: LengthRequiredConstructor;
 
         interface  PreconditionFailed extends Classes.ServerError {}
         interface  PreconditionFailedConstructor extends TherrorConstructor<PreconditionFailed> {
-            /** ServerError with statusCode: 412, message: 'Precondition Failed', level: 'error' */
+            /** ServerError with statusCode: 412, message: 'Precondition Failed', level: 'info' */
             new(): PreconditionFailed;
         }
         export let PreconditionFailed: PreconditionFailedConstructor;
 
         interface  RequestEntityTooLarge extends Classes.ServerError {}
         interface  RequestEntityTooLargeConstructor extends TherrorConstructor<RequestEntityTooLarge> {
-            /** ServerError with statusCode: 413, message: 'Request Entity Too Large', level: 'error' */
+            /** ServerError with statusCode: 413, message: 'Request Entity Too Large', level: 'info' */
             new(): RequestEntityTooLarge;
         }
         export let RequestEntityTooLarge: RequestEntityTooLargeConstructor;
 
         interface  RequestUriTooLarge extends Classes.ServerError {}
         interface  RequestUriTooLargeConstructor extends TherrorConstructor<RequestUriTooLarge> {
-            /** ServerError with statusCode: 414, message: 'Request-URI Too Large', level: 'error' */
+            /** ServerError with statusCode: 414, message: 'Request-URI Too Large', level: 'info' */
             new(): RequestUriTooLarge;
         }
         export let RequestUriTooLarge: RequestUriTooLargeConstructor;
 
         interface  UnsupportedMediaType extends Classes.ServerError {}
         interface  UnsupportedMediaTypeConstructor extends TherrorConstructor<UnsupportedMediaType> {
-            /** ServerError with statusCode: 415, message: 'Unsupported Media Type', level: 'error' */
+            /** ServerError with statusCode: 415, message: 'Unsupported Media Type', level: 'info' */
             new(): UnsupportedMediaType;
         }
         export let UnsupportedMediaType: UnsupportedMediaTypeConstructor;
 
         interface  RequestedRangeNotSatisfiable extends Classes.ServerError {}
         interface  RequestedRangeNotSatisfiableConstructor extends TherrorConstructor<RequestedRangeNotSatisfiable> {
-            /** ServerError with statusCode: 416, message: 'Requested Range Not Satisfiable', level: 'error' */
+            /** ServerError with statusCode: 416, message: 'Requested Range Not Satisfiable', level: 'info' */
             new(): RequestedRangeNotSatisfiable;
         }
         export let RequestedRangeNotSatisfiable: RequestedRangeNotSatisfiableConstructor;
 
         interface  ExpectationFailed extends Classes.ServerError {}
         interface  ExpectationFailedConstructor extends TherrorConstructor<ExpectationFailed> {
-            /** ServerError with statusCode: 417, message: 'Expectation Failed', level: 'error' */
+            /** ServerError with statusCode: 417, message: 'Expectation Failed', level: 'info' */
             new(): ExpectationFailed;
         }
         export let ExpectationFailed: ExpectationFailedConstructor;
 
         interface  ImATeapot extends Classes.ServerError {}
         interface  ImATeapotConstructor extends TherrorConstructor<ImATeapot> {
-            /** ServerError with statusCode: 418, message: 'I'm a teapot', level: 'error' */
+            /** ServerError with statusCode: 418, message: 'I'm a teapot', level: 'info' */
             new(): ImATeapot;
         }
         export let ImATeapot: ImATeapotConstructor;
 
         interface  UnprocessableEntity extends Classes.ServerError {}
         interface  UnprocessableEntityConstructor extends TherrorConstructor<UnprocessableEntity> {
-            /** ServerError with statusCode: 422, message: 'Unprocessable Entity', level: 'error' */
+            /** ServerError with statusCode: 422, message: 'Unprocessable Entity', level: 'info' */
             new(): UnprocessableEntity;
         }
         export let UnprocessableEntity: UnprocessableEntityConstructor;
 
         interface  Locked extends Classes.ServerError {}
         interface  LockedConstructor extends TherrorConstructor<Locked> {
-            /** ServerError with statusCode: 423, message: 'Locked', level: 'error' */
+            /** ServerError with statusCode: 423, message: 'Locked', level: 'info' */
             new(): Locked;
         }
         export let Locked: LockedConstructor;
 
         interface  FailedDependency extends Classes.ServerError {}
         interface  FailedDependencyConstructor extends TherrorConstructor<FailedDependency> {
-            /** ServerError with statusCode: 424, message: 'Failed Dependency', level: 'error' */
+            /** ServerError with statusCode: 424, message: 'Failed Dependency', level: 'info' */
             new(): FailedDependency;
         }
         export let FailedDependency: FailedDependencyConstructor;
 
         interface  UnorderedCollection extends Classes.ServerError {}
         interface  UnorderedCollectionConstructor extends TherrorConstructor<UnorderedCollection> {
-            /** ServerError with statusCode: 425, message: 'Unordered Collection', level: 'error' */
+            /** ServerError with statusCode: 425, message: 'Unordered Collection', level: 'info' */
             new(): UnorderedCollection;
         }
         export let UnorderedCollection: UnorderedCollectionConstructor;
 
         interface  UpgradeRequired extends Classes.ServerError {}
         interface  UpgradeRequiredConstructor extends TherrorConstructor<UpgradeRequired> {
-            /** ServerError with statusCode: 426, message: 'Upgrade Required', level: 'error' */
+            /** ServerError with statusCode: 426, message: 'Upgrade Required', level: 'info' */
             new(): UpgradeRequired;
         }
         export let UpgradeRequired: UpgradeRequiredConstructor;
 
         interface  PreconditionRequired extends Classes.ServerError {}
         interface  PreconditionRequiredConstructor extends TherrorConstructor<PreconditionRequired> {
-            /** ServerError with statusCode: 428, message: 'Precondition Required', level: 'error' */
+            /** ServerError with statusCode: 428, message: 'Precondition Required', level: 'info' */
             new(): PreconditionRequired;
         }
         export let PreconditionRequired: PreconditionRequiredConstructor;
 
         interface  TooManyRequests extends Classes.ServerError {}
         interface  TooManyRequestsConstructor extends TherrorConstructor<TooManyRequests> {
-            /** ServerError with statusCode: 429, message: 'Too Many Requests', level: 'error' */
+            /** ServerError with statusCode: 429, message: 'Too Many Requests', level: 'info' */
             new(): TooManyRequests;
         }
         export let TooManyRequests: TooManyRequestsConstructor;
 
         interface  RequestHeaderFieldsTooLarge extends Classes.ServerError {}
         interface  RequestHeaderFieldsTooLargeConstructor extends TherrorConstructor<RequestHeaderFieldsTooLarge> {
-            /** ServerError with statusCode: 431, message: 'Request Header Fields Too Large', level: 'error' */
+            /** ServerError with statusCode: 431, message: 'Request Header Fields Too Large', level: 'info' */
             new(): RequestHeaderFieldsTooLarge;
         }
         export let RequestHeaderFieldsTooLarge: RequestHeaderFieldsTooLargeConstructor;
 
         interface  UnavailableForLegalReasons extends Classes.ServerError {}
         interface  UnavailableForLegalReasonsConstructor extends TherrorConstructor<UnavailableForLegalReasons> {
-            /** ServerError with statusCode: 451, message: 'Unavailable For Legal Reasons', level: 'error' */
+            /** ServerError with statusCode: 451, message: 'Unavailable For Legal Reasons', level: 'info' */
             new(): UnavailableForLegalReasons;
         }
         export let UnavailableForLegalReasons: UnavailableForLegalReasonsConstructor;

--- a/lib/therror.js
+++ b/lib/therror.js
@@ -475,16 +475,18 @@ function getArguments(originalArguments) {
 // Create all the HTTP StatusCode commom Error clases in Therror.ServerError
 _.forEach(Therror.HTTP.STATUS_CODES, (value, key) => {
   let name = _.upperFirst(_.camelCase(value));
+  let level = parseInt(key, 10) < 500 ? 'info' : 'error';
   // Generation of typings. Uncomment and execute node lib/therror.js
   // console.log(`
   //       interface  ${name} extends Classes.ServerError {}
   //       interface  ${name}Constructor extends TherrorConstructor<${name}> {
-  //           /** ServerError with statusCode: ${key}, message: '${value}', level: 'error' */
+  //           /** ServerError with statusCode: ${key}, message: '${value}', level: '${level}' */
   //           new(): ${name};
   //       }
   //       export let ${name}: ${name}Constructor;`);
   Therror.ServerError[name] = Therror.Namespaced(name, Therror.ServerError({
-    statusCode: key
+    statusCode: key,
+    level: level
   }));
 });
 

--- a/test/therror.spec.js
+++ b/test/therror.spec.js
@@ -554,11 +554,20 @@ describe('Therror', function() {
 
       expect(err.statusCode).to.be.eql(404);
       expect(err.message).to.be.eql('The user Sarah does not exists');
+      expect(err.level()).to.be.eql('info');
       expect(err.toPayload()).to.be.eql({
         error: 'NotFound',
         message: 'The user Sarah does not exists'
       });
 
+    });
+
+    it('should have error as level for precreated classes with statusCode > 500', function() {
+
+      let err = new Therror.ServerError.InternalServerError();
+
+      expect(err.statusCode).to.be.eql(500);
+      expect(err.level()).to.be.eql('error');
     });
 
     it('should hide information to the client', function() {


### PR DESCRIPTION
BREAKING CHANGES:
For those ServerClasses which statusCode < 500, the log level will be 'info' instead of 'error'