### PR TITLE
[[FEAT]] Inherit cause message when no specific one provided

### DIFF
--- a/lib/therror.js
+++ b/lib/therror.js
@@ -61,7 +61,7 @@ class Therror extends Error {
     });
 
     this[causeSymbol] = args.cause;
-    this[templateSymbol] = _.template(args.message || 'Unknown error');
+    this[templateSymbol] = _.template(args.message || (args.cause && args.cause.message) || 'Unknown error');
   }
 
   cause() {

--- a/test/therror.spec.js
+++ b/test/therror.spec.js
@@ -59,7 +59,14 @@ describe('Therror', function() {
       let err = new Therror(cause);
 
       expect(err.cause()).to.be.eql(cause);
-      expect(err.message).to.be.eql('Unknown error');
+    });    
+    
+    it('should be able to create a Therror with cause and use cause message when no one specified', function() {
+      let cause = new Error('Causer error');
+      let err = new Therror(cause);
+
+      expect(err.cause()).to.be.eql(cause);
+      expect(err.message).to.be.eql('Causer error');
     });
 
     it('should be able to create a Therror with cause and message', function() {


### PR DESCRIPTION
````js
    it('should be able to create a Therror with cause and use cause message when no one specified', function() {
      let cause = new Error('Causer error');
      let err = new Therror(cause);

      expect(err.cause()).to.be.eql(cause);
      expect(err.message).to.be.eql('Causer error');
    });
```
