### PR TITLE
[[CHORE]] Improve Typescript support for Mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,19 +346,6 @@ More info: `Therror.parse()`
 * [therror-doc](https://github.com/therror/therror-doc): Documentation parser for therror (WIP)
 * [serr](https://github.com/therror/serr): Error serializer to Objects and Strings
 
-## TypeScript limitations
-Typescript definitons is not expressive enought (yet!) to define ES6 Mixins, which are extensively used in Therror. ([Track issue #4890 in Typescript repo](https://github.com/Microsoft/TypeScript/issues/4890)). The limitation is well explained in this [StackOverflow answer](http://stackoverflow.com/questions/39430443/typescript-definition-for-es6-mixins/39433584#39433584).
-
-TL;DR;
-If you want to create your own error classes using the provided mixins, you will need to declare the class shape on your code. We have made this super easy:
-```ts
-import Therror from 'therror';
-import { Classes } from 'therror';
-
-interface MyCustom extends Classes.Loggable, Classes.Namespaced {} // Just make this, and have full TS support for your own classes
-class MyCustom extends Therror.Loggable('info', Therror.Namespaced('MyNS')) {}
-```
-
 ## LICENSE
 
 Copyright 2014,2015,2016 [Telefónica I+D](http://www.tid.es)

--- a/lib/therror.d.ts
+++ b/lib/therror.d.ts
@@ -187,6 +187,8 @@ export declare namespace Classes {
     export class ServerError implements ServerError {}
 }
 
+type Constructor<T> = new(...args: any[]) => T;
+
 declare namespace Mixins {
     interface Namespaced {
         /**
@@ -200,7 +202,7 @@ declare namespace Mixins {
          * console.log(err) === '[Server.InvalidParamError: Not a valid parameter]';
          * ```
          */
-        (name: string, Base?: TherrorConstructor<Therror>): TherrorConstructor<Classes.Namespaced>;
+        <T extends Constructor<{}>>(name: string, Base?: T): TherrorConstructor<Classes.Namespaced & Therror> & T;
     }
 
     interface Serializable {
@@ -216,7 +218,7 @@ declare namespace Mixins {
          * console.log(err) === '[Server.InvalidParamError: Not a valid parameter]';
          * ```
          */
-        (Base?: TherrorConstructor<Therror>): TherrorConstructor<Classes.Serializable>;
+        <T extends Constructor<{}>>(Base?: T): Constructor<Classes.Serializable & Therror> & T;
     }
 
     interface Notificator {
@@ -224,7 +226,7 @@ declare namespace Mixins {
          * Mixin to add notification capabilities to this errors:
          * Its creation will emit a 'create' event, subscribable with Therror.on('create', ...)
          */
-        (Base?: TherrorConstructor<Therror>): TherrorConstructor<Classes.Notificator>;
+        <T extends Constructor<{}>>(Base?: T): Constructor<Classes.Notificator & Therror> & T;
     }
 
     interface Loggable {
@@ -250,7 +252,7 @@ declare namespace Mixins {
          * notFound.level(); // 'info'
          * ```
          */
-        (level?: string, Base?: TherrorConstructor<Therror>): TherrorConstructor<Classes.Loggable>;
+        <T extends Constructor<{}>>(level?: string, Base?: T): Constructor<Classes.Loggable & Therror> & T;
         /**
          * The Logger used to Log Loggable errors
          * @default console
@@ -268,7 +270,7 @@ declare namespace Mixins {
          * // { [UserNotFoundError: The user John does not exists] }
          * ```
          */
-        (msg: string, Base?: TherrorConstructor<Therror>): TherrorConstructor<Classes.WithMessage>;
+        <T extends Constructor<{}>>(msg: string, Base?: T): Constructor<Classes.WithMessage & Therror> & T;
     }
 
     interface HTTP {
@@ -295,7 +297,7 @@ declare namespace Mixins {
          * // }
          * ```
          */
-        (statusCode?: number|string, Base?: TherrorConstructor<Therror>): TherrorConstructor<Classes.HTTP>;
+        <T extends Constructor<{}>>(statusCode?: number|string, Base?: T): Constructor<Classes.HTTP & Therror> & T;
     }
 
     /**
@@ -347,7 +349,7 @@ declare namespace Mixins {
          * err.log(); // executes Therror.Loggable.logger.error(err);
          * ```
          */
-        (opts?: ServerErrorOptions, Base?: TherrorConstructor<Therror>): TherrorConstructor<Classes.ServerError>;
+        <T extends Constructor<{}>>(opts?: ServerErrorOptions, Base?: T): Constructor<Classes.ServerError & Therror> & T;
         BadRequest: typeof ServerErrors.BadRequest;
         Unauthorized: typeof ServerErrors.Unauthorized;
         PaymentRequired: typeof ServerErrors.PaymentRequired;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "travis": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec test/environment.js 'test/**/*.spec.js' && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage && tsc --noEmit",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R dot test/environment.js 'test/**/*.spec.js'",
     "lint": "jscs lib && eslint lib && tslint './{lib,test}/**/*.ts'",
-    "test": "mocha -R spec test/environment.js 'test/**/*.spec.js' && tsc --noEmit"
+    "test": "mocha -R spec test/environment.js 'test/**/*.spec.js' && npm run test:ts",
+    "test:ts": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^7.0.13",

--- a/test/therror.typings.ts
+++ b/test/therror.typings.ts
@@ -74,3 +74,9 @@ let myCustom = new MyCustom();
 myCustom.isTherror;
 myCustom.log();
 myCustom.namespace;
+
+class MyCustomNew extends Therror.Loggable('info', Therror.Namespaced('MyNS')) {}
+let myCustomNew = new MyCustomNew();
+myCustomNew.isTherror;
+myCustomNew.log();
+myCustomNew.namespace;


### PR DESCRIPTION
Now thanks typescript 2.2 it's not needed to declare the shape for classes created using built-in mixins

Before
```ts
import Therror from 'therror';
import { Classes } from 'therror';

interface MyCustom extends Classes.Loggable, Classes.Namespaced {}
class MyCustom extends Therror.Loggable('info', Therror.Namespaced('MyNS')) {}
```

now
```ts
import Therror from 'therror';

class MyCustom extends Therror.Loggable('info', Therror.Namespaced('MyNS')) {}
```

Breaking changes:
 * Clients with typescript < 2.2 will not be able to read the new definitions

Closes #9