### PR TITLE
[[FEAT]] Relax HTTP 5XX error mask conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ console.log(err); // [ServiceUnavailable: BD Misconfigured]
 res.statusCode(err.statusCode) // 503
 res.json(err.toPayload())
 // {
-//    error: 'InternalServerError',
-//    message: 'An internal server error occurred'
+//    error: 'ServiceUnavailable',
+//    message: 'Service Unavailable'
 // }
 ```
 

--- a/lib/therror.d.ts
+++ b/lib/therror.d.ts
@@ -180,6 +180,20 @@ export declare namespace Classes {
          * having the original properties untouched to log the error as it was defined
          */
         toPayload(): Properties;
+
+        /**
+         * Gets the message that will be sent to the user
+         * When the `statusCode` is >= 500, will return a generic message to hide implementation
+         * details to the user
+         */
+        getPayloadMessage(): string;
+
+        /**
+         * Gets the error name that will be sent to the user
+         * When the `statusCode` is >= 500, will return a generic name to hide implementation
+         * details to the user
+         */
+        getPayloadErrorName(): string;
     }
     export class HTTP implements HTTP {}
 

--- a/lib/therror.js
+++ b/lib/therror.js
@@ -331,19 +331,22 @@ class Therror extends Error {
       }
 
       toPayload() {
-        let message = this.message,
-            name = this.name;
-
-        // Hide Server Errors to the clients
-        if (statusCode >= 500) {
-          message = 'An internal server error occurred';
-          name = 'InternalServerError';
-        }
-
         return {
-          error: name,
-          message: message
+          error: this.getPayloadErrorName(),
+          message: this.getPayloadMessage()
         };
+      }
+
+      getPayloadMessage() {
+        return this.statusCode < 500 ?
+          this.message :
+          (Therror.HTTP.STATUS_CODES[this.statusCode] || Therror.HTTP.STATUS_CODES[500]);
+      }
+
+      getPayloadErrorName() {
+        return this.statusCode < 500 ?
+          this.name :
+          _.upperFirst(_.camelCase(Therror.HTTP.STATUS_CODES[this.statusCode] || Therror.HTTP.STATUS_CODES[500]));
       }
 
       get statusCode() {

--- a/test/therror.spec.js
+++ b/test/therror.spec.js
@@ -470,8 +470,8 @@ describe('Therror', function() {
       expect(err.name).to.be.eql('ServiceUnavailable');
       expect(err.message).to.be.eql('Database mongo misconfigured');
       expect(err.toPayload()).to.be.eql({
-        error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        error: 'ServiceUnavailable',
+        message: 'Service Unavailable'
       });
     });
 
@@ -487,12 +487,12 @@ describe('Therror', function() {
 
       expect(err.toPayload()).to.be.eql({
         error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        message: 'Internal Server Error'
       });
 
       expect(err2.toPayload()).to.be.eql({
         error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        message: 'Internal Server Error'
       });
     });
 
@@ -508,12 +508,12 @@ describe('Therror', function() {
 
       expect(err.toPayload()).to.be.eql({
         error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        message: 'Internal Server Error'
       });
 
       expect(err2.toPayload()).to.be.eql({
         error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        message: 'Internal Server Error'
       });
     });
 
@@ -603,8 +603,8 @@ describe('Therror', function() {
       expect(err.name).to.be.eql('ServiceUnavailable');
       expect(err.message).to.be.eql('Database mongo misconfigured');
       expect(err.toPayload()).to.be.eql({
-        error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        error: 'ServiceUnavailable',
+        message: 'Service Unavailable'
       });
     });
 
@@ -616,8 +616,8 @@ describe('Therror', function() {
       expect(err.name).to.be.eql('ServiceUnavailable');
       expect(err.message).to.be.eql('3rd party error');
       expect(err.toPayload()).to.be.eql({
-        error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        error: 'ServiceUnavailable',
+        message: 'Service Unavailable'
       });
     });
 
@@ -630,8 +630,8 @@ describe('Therror', function() {
       expect(err.message).to.be.eql('uncaught error');
       expect(err.cause()).to.be.eql(cause);
       expect(err.toPayload()).to.be.eql({
-        error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        error: 'ServiceUnavailable',
+        message: 'Service Unavailable'
       });
     });
 
@@ -643,8 +643,8 @@ describe('Therror', function() {
       expect(err.name).to.be.eql('ServiceUnavailable');
       expect(err.message).to.be.eql(String(cause));
       expect(err.toPayload()).to.be.eql({
-        error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        error: 'ServiceUnavailable',
+        message: 'Service Unavailable'
       });
     });
 
@@ -657,8 +657,8 @@ describe('Therror', function() {
       expect(err.message).to.be.eql('uncaught error');
       expect(err.cause()).to.be.eql(cause);
       expect(err.toPayload()).to.be.eql({
-        error: 'InternalServerError',
-        message: 'An internal server error occurred'
+        error: 'ServiceUnavailable',
+        message: 'Service Unavailable'
       });
     });
   });

--- a/test/therror.typings.ts
+++ b/test/therror.typings.ts
@@ -45,6 +45,8 @@ class My404 extends Therror.HTTP(404) {}
 class My503 extends Therror.HTTP('503') {}
 let my404 = new My404();
 my404.toPayload();
+my404.getPayloadErrorName();
+my404.getPayloadMessage();
 my404.statusCode;
 
 class MyCustomServerError extends Therror.ServerError({
@@ -55,6 +57,8 @@ class MyCustomServerError extends Therror.ServerError({
 class MyServerError extends Therror.ServerError() {}
 let myServerError = new MyServerError();
 myServerError.toPayload();
+myServerError.getPayloadErrorName();
+myServerError.getPayloadMessage();
 myServerError.statusCode;
 myServerError.log();
 myServerError.level;


### PR DESCRIPTION
The payload  returns a message and error that is dependant of the statusCode, not a unified unique generic one

BREAKING CHANGES:
Before
```js
class ServiceUnavailable extends Therror.HTTP(503) {}
{
  error: 'InternalServerError',
  message: 'An internal server error occurred'
}
```

After
```js
class ServiceUnavailable extends Therror.HTTP(503) {}
{
  error: 'ServiceUnavailable',
  message: 'Service Unavailable'
}
```