### PR TITLE
[[FEAT]] Use req.logger with Loggable Errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
-  - "7"
   - "8"
-script: 
+  - "10"
+  - "12"
+script:
   - "npm run travis"
   - "npm run lint"
 cache:

--- a/lib/therror.js
+++ b/lib/therror.js
@@ -231,7 +231,12 @@ class Therror extends Error {
     level = level || 'error';
     let BaseClass = Base || Therror;
     return class extends BaseClass {
-      log() {
+      log(opts) {
+        // official support for therror-connect, who calls err.log({req, res})
+        // normally, the users may set req.logger as the per-request logger
+        if (opts && opts.req && opts.req.logger && opts.req.logger[level]) {
+          return opts.req.logger[level](this);
+        }
         return Therror.Loggable.logger[level](this);
       }
 

--- a/test/therror.spec.js
+++ b/test/therror.spec.js
@@ -59,8 +59,8 @@ describe('Therror', function() {
       let err = new Therror(cause);
 
       expect(err.cause()).to.be.eql(cause);
-    });    
-    
+    });
+
     it('should be able to create a Therror with cause and use cause message when no one specified', function() {
       let cause = new Error('Causer error');
       let err = new Therror(cause);
@@ -356,14 +356,14 @@ describe('Therror', function() {
   });
 
   describe('when using Loggable', function () {
-    it('should have a log method', function() {
+    it('should have a log method', function () {
       let logger = {
         info: sandbox.spy()
       };
 
-      class MyError extends Therror.Loggable('info') {}
+      class MyError extends Therror.Loggable('info') { }
 
-      let err = new MyError('What a ${what}', {what: 'pitty'});
+      let err = new MyError('What a ${what}', { what: 'pitty' });
 
       expect(err).to.be.instanceOf(Error);
       expect(err).to.be.instanceOf(Therror);
@@ -378,6 +378,23 @@ describe('Therror', function() {
       Therror.Loggable.logger = logger;
       err.log();
       Therror.Loggable.logger = console;
+
+      expect(logger.info).to.have.been.calledWith(err);
+    });
+
+    it('should use req.logger if present', function () {
+      let logger = {
+        info: sandbox.spy()
+      };
+      const req = {
+        logger: logger
+      };
+
+      class MyError extends Therror.Loggable('info') { }
+
+      let err = new MyError('What a ${what}', { what: 'pitty' });
+
+      err.log({req: req});
 
       expect(logger.info).to.have.been.calledWith(err);
     });


### PR DESCRIPTION
Add support for the missing pattern that allows having per-request logger

```js
const express = require('express');
const Therror = require('therror');
const therrorConnect = require('therror-connect');
const logger = require('logops');

const app = express();

app.use((req, res, next) => {
  req.logger = logger.child({
    corr: 'some_string`
  });
  next();
});

app.use(therrorConnect());
```